### PR TITLE
Fix DialogPortal typing to allow className prop

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -4,11 +4,15 @@ import { X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
+type DialogPortalProps = DialogPrimitive.DialogPortalProps & {
+  className?: string;
+};
+
 const Dialog = DialogPrimitive.Root;
 
 const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = ({ className, children, ...props }: DialogPrimitive.DialogPortalProps) => (
+const DialogPortal = ({ className, children, ...props }: DialogPortalProps) => (
   <DialogPrimitive.Portal {...props}>
     <div className={cn("fixed inset-0 z-50 flex items-end justify-center sm:items-center", className)}>{children}</div>
   </DialogPrimitive.Portal>


### PR DESCRIPTION
## Summary
- extend the Dialog portal props with an optional className to satisfy TypeScript

## Testing
- npm install --no-progress *(fails: registry returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68deb177cf7c8323b792c38aac078ab4