### PR TITLE
Provide local js-cookie type declarations

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -4,11 +4,15 @@ import { X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
+type DialogPortalProps = DialogPrimitive.DialogPortalProps & {
+  className?: string;
+};
+
 const Dialog = DialogPrimitive.Root;
 
 const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = ({ className, children, ...props }: DialogPrimitive.DialogPortalProps) => (
+const DialogPortal = ({ className, children, ...props }: DialogPortalProps) => (
   <DialogPrimitive.Portal {...props}>
     <div className={cn("fixed inset-0 z-50 flex items-end justify-center sm:items-center", className)}>{children}</div>
   </DialogPrimitive.Portal>

--- a/src/types/js-cookie.d.ts
+++ b/src/types/js-cookie.d.ts
@@ -1,0 +1,31 @@
+declare module "js-cookie" {
+  type SameSite = "strict" | "lax" | "none";
+
+  interface CookieAttributes {
+    path?: string;
+    domain?: string;
+    expires?: number | Date;
+    secure?: boolean;
+    sameSite?: SameSite;
+    [property: string]: any;
+  }
+
+  interface CookiesConverter<T = string> {
+    read?: (value: string, name: string) => T;
+    write?: (value: T, name: string) => string;
+  }
+
+  interface CookiesStatic {
+    get(name: string): string | undefined;
+    get(): Record<string, string>;
+    set(name: string, value: string | object, options?: CookieAttributes): CookiesStatic;
+    remove(name: string, options?: CookieAttributes): void;
+    withAttributes(attributes: CookieAttributes): CookiesStatic;
+    withConverter<T = string>(converter: CookiesConverter<T>): CookiesStatic;
+  }
+
+  const Cookies: CookiesStatic;
+
+  export type { CookieAttributes, CookiesConverter, CookiesStatic };
+  export default Cookies;
+}


### PR DESCRIPTION
## Summary
- add a local declaration file for `js-cookie` to satisfy Next.js type checking

## Testing
- npm run build *(fails: unable to fetch Montserrat font from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deb177cf7c8323b792c38aac078ab4