### PR TITLE
Add runtime fix for testimonials animation

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -8,6 +8,8 @@ import Pricing from "@/components/sections/Pricing";
 import SocialProof from "@/components/sections/SocialProof";
 import FinalCTA from "@/components/sections/FinalCTA";
 import Footer from "@/components/sections/Footer";
+import TestimonialsDebugCard from "@/components/TestimonialsDebugCard";
+import TestimonialsRuntimeFix from "@/components/TestimonialsRuntimeFix";
 
 export default function Page() {
   return (
@@ -24,6 +26,8 @@ export default function Page() {
         <FinalCTA />
       </main>
       <Footer />
+      <TestimonialsDebugCard />
+      <TestimonialsRuntimeFix />
     </div>
   );
 }

--- a/src/components/TestimonialsDebugCard.tsx
+++ b/src/components/TestimonialsDebugCard.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import * as React from "react";
+
+// Ajuste aqui os seletores que a sua sessão usa para os cards:
+const SELECTORS = [
+  ".card-depoimento", // ex. usado nos patches anteriores
+  ".testi-left",
+  ".testi-right",
+  "[data-testimonial]",
+  "figure[data-reveal]", // genérico se você usa data-reveal
+  "section#aprovado-por-quem-usa figure"
+];
+
+type InspectResult = {
+  index: number;
+  selector: string;
+  found: number;
+  reasons: string[];
+  rect?: DOMRect;
+};
+
+export default function TestimonialsDebugCard() {
+  const [results, setResults] = React.useState<InspectResult[]>([]);
+  const [forceVisible, setForceVisible] = React.useState(false);
+  const [inView, setInView] = React.useState(false);
+  const [reduced, setReduced] = React.useState(false);
+
+  // monta/desmonta observadores sem tocar na sessão
+  React.useEffect(() => {
+    setReduced(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+
+    const sec = document.querySelector<HTMLElement>("#aprovado-por-quem-usa");
+    if (!sec) return;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => setInView(e.isIntersecting));
+      },
+      { threshold: 0.35 }
+    );
+    io.observe(sec);
+
+    const run = () => {
+      const list: InspectResult[] = [];
+      for (const selector of SELECTORS) {
+        const els = Array.from(document.querySelectorAll<HTMLElement>(selector));
+        let reasons: string[] = [];
+        els.forEach((el, i) => {
+          const cs = getComputedStyle(el);
+          const rect = el.getBoundingClientRect();
+          // motivos comuns de “sumir”
+          if (cs.display === "none") reasons.push(`display:none (${selector} [${i}])`);
+          if (cs.visibility === "hidden") reasons.push(`visibility:hidden (${selector} [${i}])`);
+          if (parseFloat(cs.opacity) < 0.05) reasons.push(`opacity≈0 (${selector} [${i}])`);
+          if (cs.clipPath && cs.clipPath !== "none") {
+            // se clip-path cobre 100% horizontalmente, é suspeito
+            reasons.push(`clip-path:${cs.clipPath}`);
+          }
+          if (/matrix.*\(.*\)/.test(cs.transform)) {
+            // apenas informativo
+            reasons.push(`transform ativo (${selector} [${i}])`);
+          }
+          if (rect.width < 8 || rect.height < 8)
+            reasons.push(`dimensões pequenas: ${Math.round(rect.width)}x${Math.round(rect.height)} (${selector} [${i}])`);
+          // checa sobreposição por z-index através do ponto central do elemento
+          const cx = Math.round(rect.left + rect.width / 2);
+          const cy = Math.round(rect.top + rect.height / 2);
+          if (rect.width > 0 && rect.height > 0) {
+            const topEl = document.elementFromPoint(cx, cy);
+            if (topEl && !el.contains(topEl) && topEl !== el) {
+              reasons.push(`possível sobreposição por ${describeEl(topEl)}`);
+            }
+          }
+          list.push({ index: i, selector, found: els.length, reasons, rect });
+        });
+        if (els.length === 0) list.push({ index: -1, selector, found: 0, reasons: ["Nenhum elemento encontrado"] });
+      }
+      setResults(list);
+    };
+
+    run();
+    const mo = new MutationObserver(run);
+    mo.observe(document.body, { childList: true, subtree: true, attributes: true });
+
+    window.addEventListener("resize", run, { passive: true });
+    window.addEventListener("scroll", run, { passive: true });
+
+    return () => {
+      io.disconnect();
+      mo.disconnect();
+      window.removeEventListener("resize", run);
+      window.removeEventListener("scroll", run);
+    };
+  }, []);
+
+  // força visualização sem alterar a sessão (apenas styling inline temporário)
+  React.useEffect(() => {
+    SELECTORS.forEach((selector) => {
+      document.querySelectorAll<HTMLElement>(selector).forEach((el) => {
+        if (forceVisible) {
+          el.dataset._debugForced = "1";
+          el.style.setProperty("opacity", "1", "important");
+          el.style.setProperty("transform", "none", "important");
+          el.style.setProperty("clip-path", "none", "important");
+          el.style.setProperty("visibility", "visible", "important");
+        } else if (el.dataset._debugForced) {
+          // limpa só o que foi setado por nós
+          el.style.removeProperty("opacity");
+          el.style.removeProperty("transform");
+          el.style.removeProperty("clip-path");
+          el.style.removeProperty("visibility");
+          delete el.dataset._debugForced;
+        }
+      });
+    });
+  }, [forceVisible]);
+
+  return (
+    <div
+      className="
+        fixed bottom-4 right-4 z-[1000] w-[340px] max-h-[70vh] overflow-auto
+        rounded-xl bg-white/95 shadow-xl ring-1 ring-black/10 backdrop-blur
+        text-sm"
+      style={{ fontFamily: "ui-sans-serif, system-ui, -apple-system" }}
+    >
+      <div className="flex items-center justify-between p-3 border-b border-slate-200">
+        <div className="font-semibold">Debug: Testimonials</div>
+        <span
+          className={`text-xs px-2 py-0.5 rounded ${inView ? "bg-emerald-100 text-emerald-700" : "bg-slate-100 text-slate-600"}`}
+        >
+          {inView ? "em viewport" : "fora da viewport"}
+        </span>
+      </div>
+
+      <div className="p-3 space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="text-slate-600">prefers-reduced-motion:</div>
+          <div className="text-slate-900 font-medium">{String(reduced)}</div>
+        </div>
+
+        <button
+          onClick={() => setForceVisible((v) => !v)}
+          className="w-full rounded-md bg-yellow-400 px-3 py-2 text-slate-900 font-semibold shadow hover:bg-yellow-300"
+        >
+          {forceVisible ? "Desativar força visível" : "Forçar visível (teste)"}
+        </button>
+
+        <div className="text-xs text-slate-500">Seletores verificados:</div>
+        <ul className="space-y-2">
+          {results.map((r, i) => (
+            <li key={i} className="rounded border border-slate-200 p-2">
+              <div className="font-mono text-[11px] break-all text-slate-700">{r.selector}</div>
+              <div className="mt-1 text-slate-700">
+                encontrados: <strong>{r.found}</strong>
+              </div>
+              {!!r.reasons.length && (
+                <ul className="mt-1 list-disc pl-4 text-slate-600">
+                  {r.reasons.map((msg, k) => (
+                    <li key={k}>{msg}</li>
+                  ))}
+                </ul>
+              )}
+              {r.rect && (
+                <div className="mt-1 text-slate-600">
+                  rect: {Math.round(r.rect.x)}x{Math.round(r.rect.y)} — {Math.round(r.rect.width)}×{Math.round(r.rect.height)}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function describeEl(el: Element) {
+  const t = el.tagName.toLowerCase();
+  const id = (el as HTMLElement).id ? `#${(el as HTMLElement).id}` : "";
+  const cls = (el as HTMLElement).className?.toString().split(" ").slice(0, 2).join(".");
+  return `${t}${id}${cls ? "." + cls : ""}`;
+}

--- a/src/components/TestimonialsRuntimeFix.tsx
+++ b/src/components/TestimonialsRuntimeFix.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Hotfix temporário:
+ * - Não modifica a sessão original.
+ * - Só observa #aprovado-por-quem-usa e força a entrada dos <figure> (ou [data-testimonial])
+ *   com transição left/right quando a sessão entra na viewport.
+ */
+export default function TestimonialsRuntimeFix() {
+  useEffect(() => {
+    const sec = document.querySelector<HTMLElement>("#aprovado-por-quem-usa");
+    if (!sec) return;
+
+    // Seleção robusta: prioriza data-attrs; fallback para <figure> dentro da sessão
+    const pickCards = () =>
+      Array.from(
+        sec.querySelectorAll<HTMLElement>(
+          "[data-testimonial], .card-depoimento, .testi-left, .testi-right, figure"
+        )
+      ).filter((el) => el.tagName.toLowerCase() === "figure" || el.hasAttribute("data-testimonial"));
+
+    const cards = pickCards();
+
+    // estado inicial seguro (não assume classes da sua animação original)
+    cards.forEach((el, i) => {
+      el.style.willChange = "transform, opacity, clip-path";
+      el.style.opacity = "0";
+      el.style.transform = `translateX(${i % 2 === 0 ? "-60px" : "60px"})`;
+      el.style.clipPath = "inset(0 100% 0 0 round 16px)";
+      el.style.transition =
+        "transform .6s cubic-bezier(.22,1,.36,1) .15s, opacity .4s ease-out .15s, clip-path .6s cubic-bezier(.22,1,.36,1) .15s";
+      // evita ficar atrás do painel escuro, sem tocar no CSS global
+      el.style.position ||= "relative";
+      el.style.zIndex ||= "1";
+    });
+
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    const onEnter = () => {
+      // anima os dois primeiros cards (ou todos, se houver mais)
+      pickCards().forEach((el, i) => {
+        // atraso levemente diferente esquerda/direita
+        const delay = i % 2 === 0 ? 150 : 280;
+        if (reduced) {
+          el.style.opacity = "1";
+          el.style.transform = "none";
+          el.style.clipPath = "inset(0 0% 0 0 round 16px)";
+        } else {
+          // usa raf para aplicar atraso respeitando CSS transition
+          setTimeout(() => {
+            el.style.opacity = "1";
+            el.style.transform = "translateX(0)";
+            el.style.clipPath = "inset(0 0% 0 0 round 16px)";
+          }, delay);
+        }
+      });
+    };
+
+    // dispara ao entrar em viewport (rootMargin ajuda em casos “quase na dobra”)
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) {
+            onEnter();
+            io.disconnect();
+          }
+        });
+      },
+      { threshold: 0.3, rootMargin: "0px 0px -10% 0px" }
+    );
+
+    io.observe(sec);
+    return () => io.disconnect();
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a runtime hotfix component that observes the testimonials section and restores the slide-in animation when cards enter the viewport
- mount the hotfix alongside the existing debug overlay on the landing page for temporary troubleshooting

## Testing
- npm run lint *(fails: No files matching the pattern "." were found)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd552f41c8323bde996ac5453d244