### PR TITLE
Add client-side gate for testimonials debug card

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
 import Header from "@/components/sections/Header";
 import Hero from "@/components/sections/Hero";
 import EventTypes from "@/components/sections/EventTypes";
@@ -12,6 +16,11 @@ import TestimonialsDebugCard from "@/components/TestimonialsDebugCard";
 import ApprovedByUsersFix from "@/components/ApprovedByUsersFix";
 
 export default function Page() {
+  const search = useSearchParams();
+  const showDebug =
+    process.env.NEXT_PUBLIC_DEBUG_UI === "1" ||
+    search.get("debug") === "testimonials";
+
   return (
     <div className="bg-bredi-bg text-bredi-neutral">
       <Header />
@@ -26,7 +35,7 @@ export default function Page() {
         <FinalCTA />
       </main>
       <Footer />
-      <TestimonialsDebugCard />
+      {showDebug ? <TestimonialsDebugCard /> : null}
       <ApprovedByUsersFix />
     </div>
   );


### PR DESCRIPTION
## Summary
- convert the landing page to a client component so the debug card can be gated client-side
- gate the testimonials debug card rendering behind query string or environment flag checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe091b5b08323b51d6aa3ba21b4e1