### PR TITLE
Revitalize ferramentas section styling

### DIFF
--- a/src/app/(site)/globals.css
+++ b/src/app/(site)/globals.css
@@ -27,42 +27,133 @@ body {
     margin-left: 0.25rem;
     animation: pisca-cursor 1s infinite;
   }
+}
 
-  .feature-item[data-reveal] {
-    opacity: 0;
-    transform: translateY(24px);
-    will-change: transform, opacity;
-  }
+/* === Sessão: Ferramentas que impulsionam seu evento === */
+#ferramentas {
+  /* fundo com grid sutil + dois glows amarelos que se movem levemente (variáveis já lidas pelo enhancer) */
+  --bredi-yellow: #facc15; /* ajuste se sua brand usar outro tom */
+  --bredi-yellow-600: #ca8a04;
+  --bgx: 0px;
+  --bgy: 0px; /* já controladas pelo enhancer, mantemos aqui para fallback */
+  background: radial-gradient(
+      900px 320px at 18% -6%,
+      rgba(250, 204, 21, 0.08),
+      transparent 60%
+    ),
+    radial-gradient(
+      800px 280px at 95% 0%,
+      rgba(250, 204, 21, 0.06),
+      transparent 60%
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.035) 0,
+      rgba(0, 0, 0, 0.035) 1px,
+      transparent 1px,
+      transparent 120px
+    );
+  background-position: var(--bgx) var(--bgy),
+    calc(100% - var(--bgx)) calc(10% + var(--bgy)), 0 0;
+}
 
-  .feature-icon {
-    background: rgba(250, 204, 21, 0.12);
-    color: #ca8a04;
-    box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.35);
-    transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1),
-      box-shadow 0.35s ease,
-      filter 0.35s ease;
-    transform: translate3d(calc(var(--mx, 0px)), calc(var(--my, 0px)), 0);
-  }
+/* heading: sublinhado sweep amarelo ao entrar (bem sutil) */
+#ferramentas .ft-heading {
+  position: relative;
+  isolation: isolate;
+}
 
-  @media (hover: hover) {
-    .feature-item:hover .feature-icon {
-      transform: translate3d(calc(var(--mx, 0px)), calc(var(--my, 0px)), 0)
-        translateY(-2px) scale(1.03);
-      box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.55),
-        0 6px 18px rgba(250, 204, 21, 0.2);
-      filter: saturate(1.05);
-    }
+#ferramentas .ft-heading::after {
+  content: "";
+  position: absolute;
+  left: 10%;
+  bottom: -8px;
+  width: 80%;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--bredi-yellow), transparent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+#ferramentas.is-in .ft-heading::after {
+  transform: scaleX(1);
+}
+
+/* item base (mantém sua grid; só reforça contraste) */
+#ferramentas .feature-item[data-reveal] {
+  opacity: 0;
+  transform: translateY(24px);
+}
+
+#ferramentas.is-in .feature-item[data-reveal] {
+  /* o enhancer faz o scrub; isto é fallback */
+  opacity: 1;
+  transform: none;
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.4s ease-out;
+}
+
+/* ícone com “tile” vibrante */
+#ferramentas .feature-icon {
+  --ring: rgba(250, 204, 21, 0.55);
+  --bg: rgba(250, 204, 21, 0.16);
+  --glow: rgba(250, 204, 21, 0.25);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--bg), rgba(250, 204, 21, 0.12));
+  box-shadow: inset 0 0 0 1px var(--ring), 0 6px 18px rgba(0, 0, 0, 0.06);
+  color: var(--bredi-yellow-600);
+  /* icone usa currentColor */
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.35s ease,
+    filter 0.35s ease, background 0.35s ease;
+  will-change: transform, box-shadow, filter;
+}
+
+/* hover/press: mais presença */
+@media (hover: hover) {
+  #ferramentas .feature-item:hover .feature-icon {
+    transform: translateY(-2px) scale(1.03);
+    box-shadow: inset 0 0 0 1px var(--ring), 0 10px 26px var(--glow);
+    filter: saturate(1.05);
   }
 }
 
+/* título do item: cor forte e destaque no foco/hover (sem mudar tipografia) */
+#ferramentas .feature-title {
+  color: #0f172a;
+  /* slate-900 */
+  text-underline-offset: 4px;
+  transition: color 0.2s ease;
+}
+
+@media (hover: hover) {
+  #ferramentas .feature-item:hover .feature-title {
+    color: #111827;
+    /* cinza mais forte */
+  }
+}
+
+/* texto: contraste melhor que o “apagado” atual */
+#ferramentas .feature-desc {
+  color: #475569;
+}
+
+/* slate-600 */
+
+/* reduz movimento */
 @media (prefers-reduced-motion: reduce) {
-  .feature-item[data-reveal] {
+  #ferramentas .feature-item[data-reveal] {
     transition: none !important;
     transform: none !important;
     opacity: 1 !important;
   }
 
-  .feature-icon {
+  #ferramentas .feature-icon {
     transition: none !important;
     transform: none !important;
   }

--- a/src/components/sections/Features.tsx
+++ b/src/components/sections/Features.tsx
@@ -90,14 +90,7 @@ function FerramentasSectionEnhancer({ children }: { children: ReactNode }) {
     <section
       ref={sectionRef}
       id="ferramentas"
-      className="
-        relative overflow-hidden py-20
-        [--bgx:0px] [--bgy:0px] [--p:0]
-        bg-white
-        before:pointer-events-none before:absolute before:inset-0 before:-z-10
-        before:bg-[radial-gradient(800px_300px_at_20%_0%,rgba(250,204,21,0.06),transparent_60%),radial-gradient(700px_280px_at_90%_10%,rgba(250,204,21,0.05),transparent_60%),repeating-linear-gradient(90deg,rgba(0,0,0,0.03)_0,rgba(0,0,0,0.03)_1px,transparent_1px,transparent_120px)]
-        before:[background-position:var(--bgx)_var(--bgy),calc(100%-var(--bgx))_calc(10%+var(--bgy)),0_0]
-      "
+      className="relative overflow-hidden bg-white"
     >
       {children}
     </section>
@@ -130,28 +123,21 @@ const features = [
 const Features = () => {
   return (
     <FerramentasSectionEnhancer>
-      <div className="container mx-auto px-6">
-        <div className="mb-12 text-center">
-          <h2 className="text-3xl font-bold uppercase text-bredi-primary md:text-4xl">
-            Ferramentas que impulsionam seu evento
-          </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-lg text-bredi-secondary">
-            Recursos extras que fazem da nossa plataforma a escolha certa.
-          </p>
-        </div>
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+      <div className="mx-auto max-w-7xl px-6 md:px-10 py-16 lg:py-24">
+        <h2 className="ft-heading text-center text-3xl sm:text-4xl lg:text-5xl font-extrabold text-slate-900">
+          FERRAMENTAS QUE IMPULSIONAM SEU EVENTO
+        </h2>
+        <p className="mt-2 text-center text-slate-600 sm:text-lg">
+          Recursos extras que fazem da nossa plataforma a escolha certa.
+        </p>
+
+        <div className="mt-12 grid grid-cols-1 gap-12 md:grid-cols-2">
           {features.map((feature) => (
-            <div
-              key={feature.title}
-              className="feature-item flex items-start p-6"
-              data-reveal
-            >
-              <div className="feature-icon mr-6 flex h-12 w-12 shrink-0 items-center justify-center rounded-lg text-bredi-accent">
-                {feature.icon}
-              </div>
+            <div key={feature.title} className="feature-item flex items-start gap-4" data-reveal>
+              <span className="feature-icon">{feature.icon}</span>
               <div>
-                <h3 className="mb-2 text-xl font-bold text-bredi-primary">{feature.title}</h3>
-                <p className="text-bredi-secondary">{feature.description}</p>
+                <h3 className="feature-title font-semibold text-xl md:text-2xl">{feature.title}</h3>
+                <p className="feature-desc mt-1">{feature.description}</p>
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- apply the new scoped styling for the "ferramentas" section, adding the animated yellow background, heading underline, and refined icon tile effects
- refresh the section markup to use the prescribed utility classes so headings, copy, and feature items pick up the new styles

## Testing
- npm run lint *(fails: No files matching the pattern "." were found)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe2e41aec8323beb2f3bc140ede3e