### PR TITLE
Ensure reduced motion hook returns boolean for testimonials grid

### DIFF
--- a/src/components/TestimonialsMetricsSection.tsx
+++ b/src/components/TestimonialsMetricsSection.tsx
@@ -53,7 +53,7 @@ const METRICS = [
 
 const TestimonialsMetricsSection = () => {
   const sectionRef = useRef<HTMLElement | null>(null);
-  const shouldReduceMotion = useReducedMotion();
+  const shouldReduceMotion = useReducedMotion() ?? false;
   const isInView = useInView(sectionRef, { margin: "-20% 0px", once: true });
 
   const { scrollYProgress } = useScroll({


### PR DESCRIPTION
## Summary
- coerce the reduced motion preference in the testimonials metrics section to a strict boolean before passing it to the grid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe69f1ebc8323af8fb8ad8164ac05