### PR TITLE
Wrap home page content in suspense boundary

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 
 import Header from "@/components/sections/Header";
@@ -15,7 +16,7 @@ import Footer from "@/components/sections/Footer";
 import TestimonialsDebugCard from "@/components/TestimonialsDebugCard";
 import ApprovedByUsersFix from "@/components/ApprovedByUsersFix";
 
-export default function Page() {
+function PageContent() {
   const search = useSearchParams();
   const showDebug =
     process.env.NEXT_PUBLIC_DEBUG_UI === "1" ||
@@ -38,5 +39,13 @@ export default function Page() {
       {showDebug ? <TestimonialsDebugCard /> : null}
       <ApprovedByUsersFix />
     </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <PageContent />
+    </Suspense>
   );
 }

--- a/src/components/TestimonialsMetricsSection.tsx
+++ b/src/components/TestimonialsMetricsSection.tsx
@@ -53,7 +53,8 @@ const METRICS = [
 
 const TestimonialsMetricsSection = () => {
   const sectionRef = useRef<HTMLElement | null>(null);
-  const shouldReduceMotion = useReducedMotion() ?? false;
+  const reduceMotionPreference = useReducedMotion();
+  const shouldReduceMotion: boolean = reduceMotionPreference ?? false;
   const isInView = useInView(sectionRef, { margin: "-20% 0px", once: true });
 
   const { scrollYProgress } = useScroll({


### PR DESCRIPTION
## Summary
- wrap the home page content in a Suspense boundary so the client-only search param hook can be used safely during prerendering

## Testing
- npm run build *(fails: unable to fetch Montserrat font from Google Fonts due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe9bb0cb483238795221fe3768485