### PR TITLE
feat: replace hero background with looping video

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -29,15 +29,19 @@ const Hero = () => {
 
   return (
     <section className="relative flex min-h-[70vh] items-center justify-center overflow-hidden bg-bredi-primary text-white md:min-h-[80vh]">
-      {banners.map((banner, index) => (
-        <div
-          key={index}
-          className={`absolute inset-0 transition-opacity duration-1000 ${index === currentBanner ? "opacity-20" : "opacity-0"}`}
-          aria-hidden={index !== currentBanner}
-        >
-          <img src={banner.imageUrl} alt="Evento" loading="lazy" className="h-full w-full object-cover" />
-        </div>
-      ))}
+      <div className="absolute inset-0">
+        <video
+          className="absolute inset-0 h-full w-full object-cover"
+          src="/hero.mp4"
+          autoPlay
+          muted
+          loop
+          playsInline
+          preload="auto"
+          aria-hidden="true"
+        />
+        <div className="absolute inset-0 bg-black/40" aria-hidden="true" />
+      </div>
       <div className="container relative z-10 mx-auto px-6 text-center">
         {banners.map((banner, index) => (
           <div


### PR DESCRIPTION
## Summary
- replace the hero section background carousel with a looping video element
- retain the dark overlay to preserve legibility of existing hero content

## Testing
- `npm run lint` *(fails: No files matching the pattern "." were found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0071508fc83238c99ab236fc8718b