### PR TITLE
Add scroll-gated hero reveal sequence

### DIFF
--- a/src/components/HeroScrollGate.tsx
+++ b/src/components/HeroScrollGate.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  childrenTop: React.ReactNode;
+  childrenBottom: React.ReactNode;
+};
+
+export default function HeroScrollGate({ childrenTop, childrenBottom }: Props) {
+  const wrapRef = useRef<HTMLElement>(null);
+  const [phase, setPhase] = useState<0 | 1 | 2>(0);
+  const [active, setActive] = useState(true);
+
+  useEffect(() => {
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduce) setPhase(2);
+  }, []);
+
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+
+    const io = new IntersectionObserver(
+      ([entry]) => setActive(entry.isIntersecting),
+      { threshold: 0.6 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!active || phase === 2) return;
+
+    let touchStartY = 0;
+
+    const advance = () => setPhase((p) => (p === 0 ? 1 : 2));
+
+    const onWheel = (e: WheelEvent) => {
+      if (e.deltaY > 0) {
+        e.preventDefault();
+        advance();
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      const keys = ["ArrowDown", "PageDown", "Space"];
+      if (keys.includes(e.code)) {
+        e.preventDefault();
+        advance();
+      }
+    };
+    const onTouchStart = (e: TouchEvent) => {
+      touchStartY = e.touches[0]?.clientY ?? 0;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      const dy = (e.touches[0]?.clientY ?? 0) - touchStartY;
+      if (dy < -12) {
+        e.preventDefault();
+        advance();
+      }
+    };
+
+    window.addEventListener("wheel", onWheel, { passive: false });
+    window.addEventListener("keydown", onKey, { passive: false });
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: false });
+
+    const prev = document.documentElement.style.overflow;
+    document.documentElement.style.overflow = "hidden";
+
+    return () => {
+      window.removeEventListener("wheel", onWheel);
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+      document.documentElement.style.overflow = prev;
+    };
+  }, [active, phase]);
+
+  useEffect(() => {
+    if (phase !== 2) return;
+    const t = setTimeout(() => {
+      document.documentElement.style.overflow = "";
+    }, 50);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  return (
+    <section ref={wrapRef} className="relative h-[100svh] overflow-hidden">
+      <video
+        className="absolute inset-0 h-full w-full object-cover"
+        src="/hero.mp4"
+        autoPlay
+        muted
+        loop
+        playsInline
+        preload="auto"
+        aria-hidden="true"
+      />
+      <div className="absolute inset-0 bg-black/40" aria-hidden="true" />
+
+      <div className="relative z-10 mx-auto flex h-full max-w-6xl flex-col items-center justify-center px-6 text-center">
+        <div
+          aria-hidden={phase < 1}
+          className={`transition-all duration-700 will-change-transform ${
+            phase >= 1 ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+          }`}
+        >
+          {childrenTop}
+        </div>
+
+        <div
+          aria-hidden={phase < 2}
+          className={`mt-6 transition-all duration-700 will-change-transform ${
+            phase >= 2 ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+          }`}
+        >
+          {childrenBottom}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react";
 
+import HeroScrollGate from "@/components/HeroScrollGate";
+
 const banners = [
   {
     title: "Venda ingressos online de forma rápida, segura e profissional.",
@@ -28,50 +30,54 @@ const Hero = () => {
   }, []);
 
   return (
-    <section className="relative flex min-h-[70vh] items-center justify-center overflow-hidden bg-bredi-primary text-white md:min-h-[80vh]">
-      <div className="absolute inset-0">
-        <video
-          className="absolute inset-0 h-full w-full object-cover"
-          src="/hero.mp4"
-          autoPlay
-          muted
-          loop
-          playsInline
-          preload="auto"
-          aria-hidden="true"
-        />
-        <div className="absolute inset-0 bg-black/40" aria-hidden="true" />
-      </div>
-      <div className="container relative z-10 mx-auto px-6 text-center">
-        {banners.map((banner, index) => (
-          <div
-            key={index}
-            className={`transition-opacity duration-1000 ${index === currentBanner ? "opacity-100" : "hidden opacity-0"}`}
-          >
-            <h1 className="mb-4 text-4xl font-extrabold uppercase leading-tight drop-shadow-lg md:text-6xl">
-              {banner.title}
-            </h1>
-            <p className="mx-auto mb-8 max-w-3xl text-lg font-light text-gray-200 drop-shadow-md md:text-2xl">
-              {banner.subtitle}
-            </p>
-          </div>
-        ))}
-        <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-          <a
-            href="#contact"
-            className="w-full transform rounded-lg border-2 border-transparent bg-bredi-accent px-10 py-4 text-lg font-bold text-bredi-primary shadow-lg transition-all hover:scale-105 hover:border-bredi-accent hover:bg-bredi-primary hover:text-bredi-accent sm:w-auto"
-          >
-            Comece agora
-          </a>
-          <a
-            href="#contact"
-            className="w-full transform rounded-lg border-2 border-bredi-accent px-10 py-4 text-lg font-bold text-bredi-accent transition-all hover:scale-105 hover:bg-bredi-accent hover:text-bredi-primary sm:w-auto"
-          >
-            Fale com nosso time
-          </a>
+    <HeroScrollGate
+      childrenTop={
+        <div>
+          {banners.map((banner, index) => (
+            <div
+              key={index}
+              className={`transition-opacity duration-1000 ${
+                index === currentBanner ? "opacity-100" : "hidden opacity-0"
+              }`}
+            >
+              <h1 className="text-4xl font-extrabold uppercase leading-tight drop-shadow-lg md:text-6xl">
+                {banner.title}
+              </h1>
+            </div>
+          ))}
         </div>
-      </div>
-    </section>
+      }
+      childrenBottom={
+        <div className="flex flex-col items-center">
+          {banners.map((banner, index) => (
+            <div
+              key={index}
+              className={`transition-opacity duration-1000 ${
+                index === currentBanner ? "opacity-100" : "hidden opacity-0"
+              }`}
+            >
+              <p className="mx-auto max-w-3xl text-lg font-light text-gray-200 drop-shadow-md md:text-2xl">
+                {banner.subtitle}
+              </p>
+            </div>
+          ))}
+          <div className="mt-8 flex w-full flex-col items-center justify-center gap-4 sm:w-auto sm:flex-row">
+            <a
+              href="#contact"
+              className="w-full transform rounded-lg border-2 border-transparent bg-bredi-accent px-10 py-4 text-lg font-bold text-bredi-primary shadow-lg transition-all hover:scale-105 hover:border-bredi-accent hover:bg-bredi-primary hover:text-bredi-accent sm:w-auto"
+            >
+              Comece agora
+            </a>
+            <a
+              href="#contact"
+              className="w-full transform rounded-lg border-2 border-bredi-accent px-10 py-4 text-lg font-bold text-bredi-accent transition-all hover:scale-105 hover:bg-bredi-accent hover:text-bredi-primary sm:w-auto"
+            >
+              Fale com nosso time
+            </a>
+          </div>
+        </div>
+      }
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
- add a reusable HeroScrollGate component to orchestrate the hero reveal phases
- wrap the hero content with the new gate so the headline and subtitle/CTAs appear on consecutive scrolls

## Testing
- npm run lint *(fails: No files matching the pattern "." were found.)*

------
https://chatgpt.com/codex/tasks/task_e_68e01302dcd48323aeedfe9d0ec0d50d