### PR TITLE
Document release procedure for PR #21

### DIFF
--- a/docs/pr21-release.md
+++ b/docs/pr21-release.md
@@ -1,0 +1,25 @@
+# Release Branch from PR #21
+
+This repository clone does not have an `origin` remote configured, so the automated release steps could not fetch the PR merge reference. Below are the steps that were attempted and their outcomes:
+
+1. `git stash -u` – skipped because no local changes were present.
+2. `git fetch origin pull/21/merge:pr21-merge` – failed with `fatal: 'origin' does not appear to be a git repository` because no remote named `origin` exists in this environment.
+
+To complete the release process once the remote is configured, follow these commands:
+
+```bash
+git fetch origin pull/21/merge:pr21-merge
+git checkout -B release/pr21 pr21-merge
+git push -u origin release/pr21
+```
+
+If the `main` branch must be reset to the merge commit from PR #21, ensure you have coordinated with collaborators and then run:
+
+```bash
+git checkout main
+git branch backup/main-before-pr21
+git reset --hard pr21-merge
+git push --force-with-lease origin main
+```
+
+Remember to verify that `origin` points to the correct remote repository before executing these commands.


### PR DESCRIPTION
## Summary
- add documentation detailing how to recreate the release branch from PR #21
- note the missing `origin` remote in this environment and outline the commands to run once configured

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01f6c25b88323baa0e084856a75e5